### PR TITLE
Add an option to disable per computer metrics

### DIFF
--- a/src/main/java/jenkins/metrics/api/MetricsAccessKey.java
+++ b/src/main/java/jenkins/metrics/api/MetricsAccessKey.java
@@ -332,6 +332,7 @@ public class MetricsAccessKey extends AbstractDescribableImpl<MetricsAccessKey> 
         @GuardedBy("this")
         private List<MetricsAccessKey> accessKeys;
         private transient volatile Set<String> accessKeySet;
+        private boolean doPerComputerMetrics = true;
 
         public DescriptorImpl() {
             super();
@@ -351,6 +352,7 @@ public class MetricsAccessKey extends AbstractDescribableImpl<MetricsAccessKey> 
         public synchronized boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             accessKeys = req.bindJSONToList(MetricsAccessKey.class, json.get("accessKeys"));
             accessKeySet = null;
+            doPerComputerMetrics = json.optString("doPerComputerMetrics").equals("true");
             save();
             return true;
         }
@@ -360,6 +362,11 @@ public class MetricsAccessKey extends AbstractDescribableImpl<MetricsAccessKey> 
             return Collections.unmodifiableList(new ArrayList<MetricsAccessKey>(
                     accessKeys == null ? Collections.<MetricsAccessKey>emptyList() : accessKeys
             ));
+        }
+
+        @NonNull
+        public synchronized Boolean getDoPerComputerMetrics() {
+            return doPerComputerMetrics;
         }
 
         public void checkAccessKey(@CheckForNull String accessKey) {

--- a/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
+++ b/src/main/java/jenkins/metrics/impl/JenkinsMetricProviderImpl.java
@@ -39,6 +39,7 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Project;
 import hudson.model.TopLevelItem;
+import jenkins.metrics.api.MetricsAccessKey;
 import jenkins.metrics.util.AutoSamplingHistogram;
 import jenkins.metrics.api.MetricProvider;
 import jenkins.metrics.api.Metrics;
@@ -509,6 +510,16 @@ public class JenkinsMetricProviderImpl extends MetricProvider {
     }
 
     private synchronized Timer getOrCreateTimer(Computer computer) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        MetricsAccessKey.DescriptorImpl descriptor = jenkins == null
+            ? null
+            : jenkins.getDescriptorByType(MetricsAccessKey.DescriptorImpl.class);
+        if (descriptor == null) {
+            throw new IllegalStateException();
+        }
+        if (!descriptor.getDoPerComputerMetrics()) {
+            return new Timer();
+        }
         Timer timer = computerBuildDurations.get(computer);
         if (timer == null) {
             timer = Metrics.metricRegistry().timer(name("jenkins", "node", computer.getName(), "builds"));

--- a/src/main/resources/jenkins/metrics/api/MetricsAccessKey/global.jelly
+++ b/src/main/resources/jenkins/metrics/api/MetricsAccessKey/global.jelly
@@ -27,5 +27,8 @@
     <f:entry title="${%Access keys}" field="accessKeys">
       <f:repeatableProperty field="accessKeys"/>
     </f:entry>
+    <f:entry title="${%Collect per computer metrics}" field="doPerComputerMetrics">
+      <f:checkbox/>
+    </f:entry>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
It's a bit of a hack to put this into the `MetricsAccessKey` class, but it turned into a bit of a mess when I tried to add it as a separate class. I even started rewriting this to have a `MetricsPluginConfiguration` class containing both `MetricsAccessKey` and a new `MetricsPerComputer` class, but the changes were too big.

In comparison, this is really short and sweet and gets the job done.